### PR TITLE
Reduce minimum deployment targets to iOS/macCatalyst 17+

### DIFF
--- a/Examples/AIChatDemo/AIChatDemo.xcodeproj/project.pbxproj
+++ b/Examples/AIChatDemo/AIChatDemo.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -305,6 +306,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Examples/AIChatDemo/AIChatDemo/AIChatDemoApp.swift
+++ b/Examples/AIChatDemo/AIChatDemo/AIChatDemoApp.swift
@@ -27,10 +27,12 @@ struct AIChatDemoApp: App {
   var body: some Scene {
     WindowGroup {
       TabView {
-        FoundationModelChatView()
-          .tabItem {
-            Label("On-Device", systemImage: "cpu")
-          }
+        if #available(iOS 26.0, macCatalyst 26.0, *) {
+          FoundationModelChatView()
+            .tabItem {
+              Label("On-Device", systemImage: "cpu")
+            }
+        }
 
         FirebaseAILogicChatView()
           .tabItem {

--- a/Examples/AIChatDemo/AIChatDemo/FoundationModelChatView.swift
+++ b/Examples/AIChatDemo/AIChatDemo/FoundationModelChatView.swift
@@ -20,6 +20,7 @@ import ConversationKit
 import FoundationModels
 import SwiftUI
 
+@available(iOS 26.0, macCatalyst 26.0, *)
 struct FoundationModelChatView {
   @State private var messages: [Message] = [
     Message(content: "Hello! How can I help you today?", participant: .other)
@@ -28,6 +29,7 @@ struct FoundationModelChatView {
   let session = LanguageModelSession()
 }
 
+@available(iOS 26.0, macCatalyst 26.0, *)
 extension FoundationModelChatView: View {
   var body: some View {
     NavigationStack {
@@ -53,5 +55,9 @@ extension FoundationModelChatView: View {
 }
 
 #Preview {
-  FoundationModelChatView()
+  if #available(iOS 26.0, macCatalyst 26.0, *) {
+    FoundationModelChatView()
+  } else {
+    Text("The Apple Foundation Models framework requires iOS 26+.")
+  }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "ConversationKit",
-  platforms: [.iOS(.v17)],
+  platforms: [.iOS(.v17), .macCatalyst(.v17)],
   products: [
     .library(
       name: "ConversationKit",


### PR DESCRIPTION
Reduced the minimum deployment targets to iOS 17+ and Mac Catalyst 17+ for the Swift package and AIChatDemo.

Note: This PR only provides initial build support for iOS 17. UI polish will still be required below iOS 26.