### PR TITLE
Add Attachment Actions Support and UI Improvements for iOS 18

### DIFF
--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -76,8 +76,7 @@ struct MessageComposerView: View {
           .offset(x: -5.0, y: 0.0)
         }
       }
-      .padding(.horizontal, 8)
-      .padding(.bottom, 8)
+      .padding([.horizontal, .bottom], 8)
     } else {
       // provide compatible attachment actions and glass effect for iOS 18 and below
       HStack(alignment: .bottom) {
@@ -86,40 +85,38 @@ struct MessageComposerView: View {
             attachmentActions
           } label: {
             Image(systemName: "plus")
-              .font(.title2)
               .foregroundColor(.primary)
-              .frame(width: 44, height: 44)
-              .background(.regularMaterial)
-              .clipShape(Circle())
-              .overlay(
-                Circle()
-                  .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
-              )
           }
+          .controlSize(.large)
+          .frame(width: 44, height: 44)
+          .background(.regularMaterial)
+          .clipShape(Circle())
+          .overlay(
+            Circle()
+              .stroke(Color(.separator), lineWidth: 0.5)
+          )
           .padding(.trailing, 8)
         }
         
         HStack(alignment: .bottom) {
           TextField("Enter a message", text: $message, axis: .vertical)
             .frame(minHeight: 32)
-            .padding(EdgeInsets(top: 7, leading: 16, bottom: 7, trailing: 0))
+            .padding(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 0))
             .onSubmit(of: .text) { onSubmitAction() }
           
           Button(action: { onSubmitAction() }) {
             Image(systemName: "arrow.up")
-              .font(.system(size: 16, weight: .semibold))
-              .foregroundColor(.white)
-              .frame(width: 32, height: 32)
-              .background(Color.accentColor)
-              .clipShape(Circle())
           }
-          .padding(EdgeInsets(top: 7, leading: 0, bottom: 7, trailing: 7))
+          .buttonStyle(.borderedProminent)
+          .buttonBorderShape(.circle)
+          .controlSize(.regular)
+          .padding(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 7))
         }
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 22))
         .overlay(
           RoundedRectangle(cornerRadius: 22)
-            .stroke(Color.gray.opacity(0.2), lineWidth: 0.5)
+            .stroke(Color(.separator), lineWidth: 0.5)
         )
       }
       .padding(.top, 8)
@@ -206,4 +203,3 @@ struct MessageComposerView: View {
     .navigationBarTitleDisplayMode(.inline)
   }
 }
-

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -79,18 +79,51 @@ struct MessageComposerView: View {
       .padding(.horizontal, 8)
       .padding(.bottom, 8)
     } else {
-      HStack {
-        TextField("Enter a message", text: $message, axis: .vertical)
-          .textFieldStyle(.automatic)
-          .onSubmit(of: .text) { onSubmitAction() }
-        Button(action: { onSubmitAction() }) {
-          Image(systemName: "arrow.up.circle.fill")
-            .font(.title)
+      // provide compatible attachment actions and glass effect for iOS 18 and below
+      HStack(alignment: .bottom) {
+        if !disableAttachments {
+          Menu {
+            attachmentActions
+          } label: {
+            Image(systemName: "plus")
+              .font(.title2)
+              .foregroundColor(.primary)
+              .frame(width: 44, height: 44)
+              .background(.regularMaterial)
+              .clipShape(Circle())
+              .overlay(
+                Circle()
+                  .stroke(Color.gray.opacity(0.3), lineWidth: 0.5)
+              )
+          }
+          .padding(.trailing, 8)
         }
+        
+        HStack(alignment: .bottom) {
+          TextField("Enter a message", text: $message, axis: .vertical)
+            .frame(minHeight: 32)
+            .padding(EdgeInsets(top: 7, leading: 16, bottom: 7, trailing: 0))
+            .onSubmit(of: .text) { onSubmitAction() }
+          
+          Button(action: { onSubmitAction() }) {
+            Image(systemName: "arrow.up")
+              .font(.system(size: 16, weight: .semibold))
+              .foregroundColor(.white)
+              .frame(width: 32, height: 32)
+              .background(Color.accentColor)
+              .clipShape(Circle())
+          }
+          .padding(EdgeInsets(top: 7, leading: 0, bottom: 7, trailing: 7))
+        }
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+        .overlay(
+          RoundedRectangle(cornerRadius: 22)
+            .stroke(Color.gray.opacity(0.2), lineWidth: 0.5)
+        )
       }
       .padding(.top, 8)
       .padding([.horizontal, .bottom], 16)
-      .background(.thinMaterial)
     }
   }
 }


### PR DESCRIPTION
## Problem Description

- iOS version 18 lack `attachmentActions` functionality
- UI layout for lower iOS versions differs significantly from higher versions

<img width="300" alt="Screenshot 2025-07-30 at 12 13 14 PM" src="https://github.com/user-attachments/assets/4ae85b8f-a678-4aff-b466-c4051e14974e" />


## Solution

### 1. Add Attachment Actions Support
- Implemented `attachmentActions` support for iOS 18
- Used `Menu` component to provide attachment operation menus

### 2. Improve UI Consistency
- Redesigned the layout for lower iOS versions to maintain consistency with higher versions
- Replaced simple `.thinMaterial` with `.regularMaterial` background

The new UI layout:

<img width="300" alt="Screenshot 2025-07-30 at 12 17 08 PM" src="https://github.com/user-attachments/assets/b018dd5c-0d3e-43da-a3ac-2ebd8ebcae74" />


