### PR TITLE
chore: exclude AGENTS.md documentation from ConversationKitTests target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
       ]),
     .testTarget(
       name: "ConversationKitTests",
-      dependencies: ["ConversationKit"]),
+      dependencies: ["ConversationKit"],
+      exclude: ["AGENTS.md"]),
   ]
 )


### PR DESCRIPTION
This PR excludes the AGENTS.md file from the ConversationKitTests target resources in Package.swift, resolving the SPM unhandled resource target warning.