### PR TITLE
refactor: modernize color styling modifiers using foregroundStyle

### DIFF
--- a/Sources/ConversationKit/Views/AttachmentPreviewCard.swift
+++ b/Sources/ConversationKit/Views/AttachmentPreviewCard.swift
@@ -33,7 +33,7 @@ public struct AttachmentPreviewCard<AttachmentType: Attachment & View>: View {
       
       Button(action: onDelete) {
         Image(systemName: "xmark.circle.fill")
-          .foregroundColor(.white)
+          .foregroundStyle(.white)
           .background(Circle().fill(Color.black.opacity(0.6)))
       }
       .padding(4)

--- a/Sources/ConversationKit/Views/MessageView.swift
+++ b/Sources/ConversationKit/Views/MessageView.swift
@@ -44,7 +44,7 @@ public struct MessageView: View {
       else {
         Image(systemName: "sparkles")
           .font(.title2)
-          .foregroundColor(.accentColor)
+          .foregroundStyle(Color.accentColor)
       }
       VStack(alignment: participant == .user ? .trailing : .leading) {
         if let error {


### PR DESCRIPTION
This PR replaces the deprecated .foregroundColor modifier with .foregroundStyle in MessageView.swift and AttachmentPreviewCard.swift.