### PR TITLE
refactor: add VoiceOver accessibility labels to icon-only buttons

### DIFF
--- a/Sources/ConversationKit/Model/ImageAttachment.swift
+++ b/Sources/ConversationKit/Model/ImageAttachment.swift
@@ -42,5 +42,6 @@ extension ImageAttachment: View {
       .aspectRatio(contentMode: .fill)
       .frame(width: 100, height: 100)
       .modifier(ConcentricClipShapeModifier())
+      .accessibilityLabel("Photo attachment")
   }
 }

--- a/Sources/ConversationKit/Views/AttachmentPreviewCard.swift
+++ b/Sources/ConversationKit/Views/AttachmentPreviewCard.swift
@@ -36,6 +36,7 @@ public struct AttachmentPreviewCard<AttachmentType: Attachment & View>: View {
           .foregroundStyle(.white)
           .background(Circle().fill(Color.black.opacity(0.6)))
       }
+      .accessibilityLabel("Remove attachment")
       .padding(4)
     }
   }

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -80,7 +80,6 @@ public struct MessageComposerView<AttachmentType: Attachment & View>: View {
   public var body: some View {
     HStack(alignment: .bottom) {
       
-      // Plus button sits OUTSIDE the text pill on both iOS and macOS now
       if !disableAttachments, let attachmentActions {
         Menu {
           attachmentActions
@@ -93,6 +92,7 @@ public struct MessageComposerView<AttachmentType: Attachment & View>: View {
             .font(.callout.weight(.medium))
             #endif
         }
+        .accessibilityLabel("Add attachment")
         .menuStyle(.borderlessButton)
         #if os(iOS)
         .controlSize(.large)

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -157,6 +157,7 @@ public struct MessageComposerView<AttachmentType: Attachment & View>: View {
               .font(isGenerating ? .system(size: 14, weight: .black) : .body.weight(.semibold))
               #endif
           }
+          .accessibilityLabel(isGenerating ? "Stop generating" : "Send message")
           .disabled(!isGenerating && !canSubmit)
           #if os(iOS)
           .buttonStyle(.borderedProminent)

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -157,7 +157,7 @@ public struct MessageComposerView<AttachmentType: Attachment & View>: View {
               .font(isGenerating ? .system(size: 14, weight: .black) : .body.weight(.semibold))
               #endif
           }
-          .accessibilityLabel(isGenerating ? "Stop generating" : "Send message")
+          .accessibilityLabel(isGenerating ? Text("Stop generating") : Text("Send message"))
           .disabled(!isGenerating && !canSubmit)
           #if os(iOS)
           .buttonStyle(.borderedProminent)

--- a/Sources/ConversationKit/Views/MessageView.swift
+++ b/Sources/ConversationKit/Views/MessageView.swift
@@ -45,6 +45,7 @@ public struct MessageView: View {
         Image(systemName: "sparkles")
           .font(.title2)
           .foregroundStyle(Color.accentColor)
+          .accessibilityHidden(true)
       }
       VStack(alignment: participant == .user ? .trailing : .leading) {
         if let error {
@@ -66,8 +67,10 @@ public struct MessageView: View {
                   image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                    .accessibilityLabel("Attached image")
                 } else if phase.error != nil {
                   Image(systemName: "icloud.slash")
+                    .accessibilityLabel("Image failed to load")
                 } else {
                   ProgressView()
                 }


### PR DESCRIPTION
This PR adds accessibilityLabel to the delete attachment button and the compose submit/stop button to ensure VoiceOver screen readers can announce their actions correctly.