### PR TITLE
refactor: resolve @Entry closure warnings by introducing nominal wrappers

### DIFF
--- a/Sources/ConversationKit/Views/ConversationEnvironment.swift
+++ b/Sources/ConversationKit/Views/ConversationEnvironment.swift
@@ -9,15 +9,27 @@ import SwiftUI
 
 // MARK: - Message Actions
 
+public struct MessageActions {
+  private let handler: (any Message) -> AnyView
+  
+  public init(handler: @escaping (any Message) -> AnyView) {
+    self.handler = handler
+  }
+  
+  public func callAsFunction(_ message: any Message) -> AnyView {
+    handler(message)
+  }
+}
+
 public extension EnvironmentValues {
-  @Entry var messageActions: ((any Message) -> AnyView)?
+  @Entry var messageActions: MessageActions?
 }
 
 public extension View {
   /// Defines a custom view to be displayed below AI messages (e.g. thumbs up/down, copy, regenerate).
   /// - Parameter actions: A closure that takes a `Message` and returns a View.
   func messageActions<V: View>(@ViewBuilder actions: @escaping (any Message) -> V) -> some View {
-    environment(\.messageActions, { message in AnyView(actions(message)) })
+    environment(\.messageActions, MessageActions(handler: { message in AnyView(actions(message)) }))
   }
 }
 

--- a/Sources/ConversationKit/Views/ConversationEnvironment.swift
+++ b/Sources/ConversationKit/Views/ConversationEnvironment.swift
@@ -10,12 +10,13 @@ import SwiftUI
 // MARK: - Message Actions
 
 public struct MessageActions {
-  private let handler: (any Message) -> AnyView
+  private let handler: @MainActor (any Message) -> AnyView
   
-  public init(handler: @escaping (any Message) -> AnyView) {
+  public init(handler: @escaping @MainActor (any Message) -> AnyView) {
     self.handler = handler
   }
   
+  @MainActor
   public func callAsFunction(_ message: any Message) -> AnyView {
     handler(message)
   }
@@ -28,7 +29,8 @@ public extension EnvironmentValues {
 public extension View {
   /// Defines a custom view to be displayed below AI messages (e.g. thumbs up/down, copy, regenerate).
   /// - Parameter actions: A closure that takes a `Message` and returns a View.
-  func messageActions<V: View>(@ViewBuilder actions: @escaping (any Message) -> V) -> some View {
+  @MainActor
+  func messageActions<V: View>(@ViewBuilder actions: @escaping @MainActor (any Message) -> V) -> some View {
     environment(\.messageActions, MessageActions(handler: { message in AnyView(actions(message)) }))
   }
 }

--- a/Sources/ConversationKit/Views/ConversationView.swift
+++ b/Sources/ConversationKit/Views/ConversationView.swift
@@ -18,10 +18,20 @@
 import SwiftUI
 import MarkdownUI
 
-extension EnvironmentValues {
-  @Entry var onSendMessageAction: (_ message: any Message) async -> Void = { message in
-    // no-op
+public struct OnSendMessageAction {
+  private let handler: (any Message) async -> Void
+  
+  public init(handler: @escaping (any Message) async -> Void) {
+    self.handler = handler
   }
+  
+  public func callAsFunction(_ message: any Message) async {
+    await handler(message)
+  }
+}
+
+extension EnvironmentValues {
+  @Entry var onSendMessageAction: OnSendMessageAction = OnSendMessageAction(handler: { _ in })
 }
 
 public extension View {
@@ -37,7 +47,7 @@ public extension View {
   ///   the content into a different model with a new UUID, the internal deduplication will fail and
   ///   the message will briefly appear twice.
   func onSendMessage(_ action: @escaping (_ message: any Message) async -> Void) -> some View {
-    environment(\.onSendMessageAction, action)
+    environment(\.onSendMessageAction, OnSendMessageAction(handler: action))
   }
 }
 

--- a/Sources/ConversationKit/Views/ConversationView.swift
+++ b/Sources/ConversationKit/Views/ConversationView.swift
@@ -19,12 +19,13 @@ import SwiftUI
 import MarkdownUI
 
 public struct OnSendMessageAction {
-  private let handler: (any Message) async -> Void
+  private let handler: @MainActor (any Message) async -> Void
   
-  public init(handler: @escaping (any Message) async -> Void) {
+  public init(handler: @escaping @MainActor (any Message) async -> Void) {
     self.handler = handler
   }
   
+  @MainActor
   public func callAsFunction(_ message: any Message) async {
     await handler(message)
   }
@@ -46,7 +47,8 @@ public extension View {
   ///   permanently store it. The exact `id` of the `message` parameter must be preserved; if you copy
   ///   the content into a different model with a new UUID, the internal deduplication will fail and
   ///   the message will briefly appear twice.
-  func onSendMessage(_ action: @escaping (_ message: any Message) async -> Void) -> some View {
+  @MainActor
+  func onSendMessage(_ action: @escaping @MainActor (_ message: any Message) async -> Void) -> some View {
     environment(\.onSendMessageAction, OnSendMessageAction(handler: action))
   }
 }

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -19,24 +19,26 @@
 import SwiftUI
 
 public struct OnSubmitAction {
-  private let handler: () -> Void
+  private let handler: @MainActor () -> Void
   
-  public init(handler: @escaping () -> Void = {}) {
+  public init(handler: @escaping @MainActor () -> Void = {}) {
     self.handler = handler
   }
   
+  @MainActor
   public func callAsFunction() {
     handler()
   }
 }
 
 public struct OnStopAction {
-  private let handler: () -> Void
+  private let handler: @MainActor () -> Void
   
-  public init(handler: @escaping () -> Void = {}) {
+  public init(handler: @escaping @MainActor () -> Void = {}) {
     self.handler = handler
   }
   
+  @MainActor
   public func callAsFunction() {
     handler()
   }
@@ -52,13 +54,15 @@ extension EnvironmentValues {
 
 public extension View {
   /// Defines the closure executed when the user taps the send button (or hits return).
-  func onSubmitAction(_ action: @escaping () -> Void) -> some View {
+  @MainActor
+  func onSubmitAction(_ action: @escaping @MainActor () -> Void) -> some View {
     environment(\.onSubmitAction, OnSubmitAction(handler: action))
   }
   
   /// Defines the closure executed when the user taps the stop button during active generation.
   /// Used to cooperatively cancel the background task running the submit action.
-  func onStopAction(_ action: @escaping () -> Void) -> some View {
+  @MainActor
+  func onStopAction(_ action: @escaping @MainActor () -> Void) -> some View {
     environment(\.onStopAction, OnStopAction(handler: action))
   }
   

--- a/Sources/ConversationKit/Views/MessageComposerView.swift
+++ b/Sources/ConversationKit/Views/MessageComposerView.swift
@@ -18,9 +18,33 @@
 
 import SwiftUI
 
+public struct OnSubmitAction {
+  private let handler: () -> Void
+  
+  public init(handler: @escaping () -> Void = {}) {
+    self.handler = handler
+  }
+  
+  public func callAsFunction() {
+    handler()
+  }
+}
+
+public struct OnStopAction {
+  private let handler: () -> Void
+  
+  public init(handler: @escaping () -> Void = {}) {
+    self.handler = handler
+  }
+  
+  public func callAsFunction() {
+    handler()
+  }
+}
+
 extension EnvironmentValues {
-  @Entry var onSubmitAction: () -> Void = {}
-  @Entry var onStopAction: () -> Void = {}
+  @Entry var onSubmitAction: OnSubmitAction = OnSubmitAction()
+  @Entry var onStopAction: OnStopAction = OnStopAction()
   @Entry var isGenerating: Bool = false
   @Entry var disableAttachments: Bool = false
   @Entry var attachmentActions: AnyView? = nil
@@ -29,13 +53,13 @@ extension EnvironmentValues {
 public extension View {
   /// Defines the closure executed when the user taps the send button (or hits return).
   func onSubmitAction(_ action: @escaping () -> Void) -> some View {
-    environment(\.onSubmitAction, action)
+    environment(\.onSubmitAction, OnSubmitAction(handler: action))
   }
   
   /// Defines the closure executed when the user taps the stop button during active generation.
   /// Used to cooperatively cancel the background task running the submit action.
   func onStopAction(_ action: @escaping () -> Void) -> some View {
-    environment(\.onStopAction, action)
+    environment(\.onStopAction, OnStopAction(handler: action))
   }
   
   /// Injects the current background execution state to toggle the Send button into a Stop button.


### PR DESCRIPTION
This PR introduces MessageActions, OnSendMessageAction, OnSubmitAction, and OnStopAction nominal wrapper structs to hold Environment closure values. This completely resolves the compiler warnings in Swift 6 regarding storing non-comparable closures inside @Entry.